### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Checkout [Links to Shopify checkout]
 First, link a Shopify product and a Wordpress page:
 
 1. Create a product in Shopify.
-1. Create and name a page for the product in Wordpress.
+1. Create a page for the product in Wordpress.
 1. You should see a new metabox in Wordpress that has a field for the product ID. Fill in the product ID from your Shopify store. 
      * The easiest way to find the ID of a product is to navigate to the "edit" page for that product within Shopify, and copy the last section of the URL for that page. For example, if when editing the product your url is *example.myshopify.com/admin/products/__12345__*, then the ID for that product is __12345__.
 
@@ -91,9 +91,9 @@ Next, prepare the markup for the product pages:
 1. **Wrap your product in an element with `data-product-id` set correctly.** For example, when in the Loop:
     
         <div class="product-wrapper" data-product-id="<?php the_product_id(); ?>">
-            <!-- the_product_id() will fill in the product ID - see "Advanced" below -->
+            <!-- the_product_id() will fill in the product ID - see "Advanced -> Convenience Functions" below -->
         </div>
-1. Fill the wrapper with `data-product` shortcuts and/or custom Underscore templates. See below for examples.
+1. Fill the wrapper with `data-product` shortcuts and/or custom Underscore templates. See Product Templates below for examples.
 
 Finally, prepare the markup for the cart page:
 
@@ -101,7 +101,7 @@ Finally, prepare the markup for the cart page:
 
         <div data-cart-id=""></div>
         
-1. Fill the wrapper with `data-cart` shortcuts and/or custom Underscore templates. See below for examples.
+1. Fill the wrapper with `data-cart` shortcuts and/or custom Underscore templates. See Cart Templates below for examples.
 
 ## Product Templates
 
@@ -130,18 +130,18 @@ Set the `data-template` attribute equal to one of these included templates:
 * `variants-radio` (renders a product's variants as radio buttons - does not handle callbacks! Use `data-product="radio"` to render the template and have wp-shopify set up the callbacks for you)
 * `variants-select` (renders a product's variants as a dropdown menu - does not handle callbacks! Use `data-product="select"` to render the template and have wp-shopify set up the callbacks for you)
 
-You can also build your own custom template:
+You can also build your own custom templates:
 
 1. If one doesn't exist yet, create a folder in your theme's directory called `wshop-templates`.
 1. Create a PHP file. This file's name will be the template name. For example: `wshop-templates/custom-template.php`.
 1. Create an an inline script in the PHP file to serve as the Underscore template.
-1. Set the script's ID to match the file name.
+1. Set the script's ID to match the file name: `<script type="text/template" id="custom-template">`
 
 Custom templates have access to the `data` variable, which contains all information about the current product returned from Shopify's API.
 
-All contents of the `wshop-templates` directory will be included in the footer of your site, hooking into the `get_footer()` function. You can have full control over the data you received from Shopify this way.
+All contents of the `wshop-templates` directory will be included in the footer of your site, hooking into the `get_footer()` function.
 
-## Setting Up a Cart
+## Cart Templates
 Any carts on the page will work much in the same way as the products do. The main difference is that we don't necessarily have to specify a cart ID:
 ```html
 <!-- Perfectly valid cart wrapper -->
@@ -149,48 +149,28 @@ Any carts on the page will work much in the same way as the products do. The mai
 
 </div>
 ```
-# TODO: Start here
-You can use `data-cart` attributes just like `data-product`, as well as custom Underscore templates:
 
-```html
-<div data-cart-id="">
+#### Using `data-cart`
 
-    <!-- The individual items -->
-    <div data-cart="line-items">
-        <!-- Each item in the cart will be rendered using wshop-templates/cart-line-item.php here -->
-    </div>
-    
-    <!-- The subtotal of the user's cart -->
-    <div data-cart="subtotal"></div>
-    
-    <!-- The total number of items in the current cart (default 0) -->
-    <div data-cart="line-item-count"></div>
- 
-    <!-- MUST BE AN <a> TAG. href will automatically be set to Shopify checkout URL. You can also use wshop.cart.checkoutUrl at any time to get the checkout URL. -->
-    <a data-cart="checkout">Checkout</a>
-    
-    <!-- Increment one of the quantity of the given item in the cart -->
-    <div data-cart="add"></div>
-    
-    <!-- Decrement one of the quantity of the given item in the cart -->
-    <div data-cart="subtract"></div>
-    
-    <!-- Remove an item from the cart entirely -->
-    <div data-cart="remove"></div>
+You can use `data-cart` attributes just like `data-product`. Place any of the following attributes on elements in the `data-cart-id` wrap:
 
-</div>
-```
+* `data-cart="line-items"` - Renders each item in the cart with the `cart-line-items` template.
+* `data-cart="subtotal"` - The subtotal of the products in the cart.
+* `data-cart="line-item-count"` - The number of items in the cart (default 0).
+* `data-cart="checkout"` - **Must be on an <a> tag.** Sets `href` to the Shopify checkout URL. You can also access this URL in JS any time via `wshop.cart.checkoutUrl`.
+* `data-cart="add"` - Add one of a given item to your cart on click. Rerenders the cart.
+* `data-cart="subtract"` - Remove one of a given item from your cart on click. Rerenders the cart.
+* `data-cart="remove"` - Remove all of a given item from your cart on click. Rerenders the cart.
 
-### Cart Custom Templates Reference
+### Using Custom Cart Templates
 Custom Underscore cart templates are set up in the same way as custom product templates. You have access to a `data` variable that contains all the information about each item in a cart, as well as the quantity in the cart and other stats. For example:
+
 
 ```html
 <script type="text/template" id="cart-line-item">
     <% console.log(data); // Log available data %>
 </script>
 ```
-
-
 
 ## Advanced
 ### Events

--- a/README.md
+++ b/README.md
@@ -207,6 +207,27 @@ wp-shopify comes with PHP convenience functions to check for, fetch, and display
 * `get_the_product_id( $post )` is returns the product ID of a given page, as defined in the 'Product ID' metadata. If there is no product ID attached to a page, it returns a blank string.
 * `the_product_id( $post )` echoes the return value of `get_the_product_id()`.
 
+### Adding Custom Quantities to Carts
+The `data-product="add-to-cart"` element will only add one of a given product to a cart. To add custom quantities, do this in your JS:
+
+```
+// html
+<div data-product-id="...">
+    <div id="example"> Click me to add custom quantities </div>
+</div>
+
+// js
+jQuery('#example').on('click', function(){
+    // the custom quantity (any integer)
+    var quantity = 5; 
+    
+    // bind `wshop.addToCart` to `this`, then pass the custom quantity
+    wshop.addToCart.bind(this)(quantity);
+});
+```
+
+`addToCart.bind(this)` makes sure that the addToCart function looks for `this`'s product wrapper and adds the appropriate amount and variant.
+
 ### Overriding Included Templates
 Making a file with the same name as one of the included templates will override that template - so, for example, if you create a `product-gallery` template in your theme's `wshop-templates` directory, it will override the plugin's default `product-gallery` template.
 ### Setting Up External Custom Styling

--- a/README.md
+++ b/README.md
@@ -10,113 +10,101 @@ A Wordpress-Shopify Integration plugin by Funkhaus
 
 ```
 
+# TODO
+* Convert `data-product="select"` to radio
+
 # Table of Contents
-1. [What Is It?](#What-is-it?)
-1. [Setup](#Setup)
-1. The Product Wrapper
-1. Rendering Information
-    1. `data-` shortcuts
-    1. Templates
-1. [Advanced](#Advanced)
+1. What Is It?
+1. Installation
+1. How to Use
+    1. Setting Up a Product
+    1. Product Templating Reference
+        1. `data-product` Shortcuts
+        1. Custom Templates
+    1. Setting Up a Cart
+1. Examples
+1. Advanced
+    1. Wrapper Classes
+    1. Convenience PHP Functions
+    1. Events
 
 ## What is it?
 wp-shopify is an integration tool built around the [Shopify Buy API](https://help.shopify.com/api/sdks/js-buy-sdk).
 
-From a high-level perspective, the plugin allows you to easily add a basic e-commerce store into a Wordpress site without having to get your hands dirty in all the messy logic that comes with e-commerce projects. It allows you to write templates and develop a theme just as you normally would, pulling product and cart data straight from Shopify and leveraging the API for all the hard work.
+wp-shopify integrates a basic e-commerce store into a Wordpress site without having to get your hands dirty in all the messy logic that comes with e-commerce projects. You can write templates and develop a theme just as you normally would, pulling product and cart data straight from Shopify and leveraging the API for all the hard work.
 
-The basic workflow is this:
-1. Set up a product wrapper.
-2. Use `data-` attributes to fill in basic product information, and/or
-3. Use templates to fill in more advanced and customized product information.
-
-## Setup
+## Installation
 
 ### Shopify
 First, you'll need your Shopify store up and running.
 
-1. Set up a shopify store and enable the [Buy Button Channel](https://www.shopify.com/buy-button).
-1. Create an access token by going to [the Extensions page](https://what-youth-test.myshopify.com/admin/apps/private/extensions) (accessed via Buy Button -> Create Extension, then the Create Extension button in the upper right hand corner).
-1. Note the access token for use later on.
+1. Set up a Shopify store and enable the [Buy Button Channel](https://www.shopify.com/buy-button).
+1. Create an access token by going to the Buy Button Extensions page at your-site.myshopify.com/admin/apps/private/extensions and clicking **Create Extension** in the top right corner.
+1. Add any product(s) you'll be selling.
 
 ### Wordpress
 After Shopify has been set up, you'll be able to start the Wordpress installation.
 
 1. Download this repo and drop it into your plugins folder. Enable it through your plugin settings and then navigate to __Tools > Shopify__. 
-1. Put in your API key (the access token from the Shopify steps above), Shopify domain, and app ID. More info here on where to find that: https://help.shopify.com/api/guides/api-credentials
+1. Put in your API key (the access token from step 2 above), Shopify domain, and app ID. More info here on where to find that: https://help.shopify.com/api/guides/api-credentials
 
-You can now start creating a page or pages that will serve as a placeholder for an individual products. 
+You can now start creating a page or pages that will serve as a placeholder for an individual product. 
 
-1. Create and name a page for a product as you normally would. 
+## How to Use
+After installation, you'll need to set up both your product on Shopify and a page for that product in Wordpress.
+
+### Setting Up a Product Page
+1. Create and name a page for a product as you normally would in Wordpress.
 1. You should see a new metabox under the page content that has a field for the product ID. Fill in the product ID from your Shopify store. 
      * The easiest way to find the ID of a product is to navigate to the "edit" page for that product within Shopify, and copy the last section of the URL for that page. For example, if when editing the product your url is *example.myshopify.com/admin/products/__12345__*, then the ID for that product is __12345__.
 
-Once you have at least one product set up and the Shopify ID saved, then you're ready to start filling in information.
+Once you have at least one product set up and the Shopify ID saved, then you're ready to start templating product information.
 
-## The Product Wrapper
-
+### Product Templating Reference
 First, **prepare a wrapper for your product.** Include a `data-product-id` attribute set to the product ID.
 ```html
 <div class="product-wrapper" data-product-id="<?php the_product_id(); ?>">
-    <!-- data-attribute shortcuts and template rendering will live here -->
+    <!-- the_product_id() will fill in the product ID - see "Advanced" below -->
 </div>
 ```
-#### Wrapper Classes
-There are informational classes added to product wrappers upon rendering:
-* `has-variants` will be added to any product that has variants on Shopify.
-* `product-unavailable` will be added to any product whose inventory is less than or equal to 0 (or is unavailable for any other reason). 
 
-#### Wrapper Convenience Functions
-wp-shopify comes with PHP convenience functions to check for, fetch, and display product IDs. Note that `$post` is optional in all of these functions and defaults to the current post.
-* **`has_product( $post )`** returns `true` if the page has a product ID set, `false` if not.
-* **`get_the_product_id( $post )`** is returns the product ID of a given page, as defined in the 'Product ID' metadata. If there is no product ID attached to a page, it returns a blank string.
-* **`the_product_id( $post )`** echoes the return value of `get_the_product_id()`.
-
-## Rendering Information
-Inside your product wrapper, you can use:
-* `data-product` shortcuts to display information pulled from Shopify, and/or
+Inside your wrapper, you can use any combination of these features to display product information:
+* `data-product` shortcuts to display basic information, and/or
 * Custom templates for more in-depth display control.
 
-### `data-product` Shortcuts
-
+#### `data-product` Shortcuts
 You can set the attribute `data-product` on any HTML tag to fill in some common information about products pulled from Shopify.
-
-- __`data-product="title"`__: The Shopify title of the product.
-- __`data-product="price"`__: The price of the product, does not include symbol of currency.
-- __`data-product="description"`__: The Shopify description of the product.
-- __`data-product="type"`__: The Shopify product-type of the product.
-- __`data-product="image"`__: The featured image of the product from Shopify. Image will be inserted into the element as an img tag.
-- __`data-product="select"`__: If the product has any variants, this element will be filled with a `<select>` that when changed by the user will switch out which variant of the product is being selected.
-- __`data-product="add-to-cart"`__: When clicked, the element with this data-attribute will add the product (or currently selected variant of the product) to the current user's cart.
-
-#### Example Shortcut Implementation
 
 First, we create the product wrapper:
 
 ```html
-<div class="single-product" data-product-id="<?php the_product_id(); ?>"></div>
+<div data-product-id="<?php the_product_id(); ?>">
+    
+</div>
 ```
 
-The ID you saved to the product in Wordpress was saved with the key `_wshop_product_id`, which was accessed and echoed with `the_product_id()`. The line above will tell wp-shopify that everything within this div will be in reference to this product's ID.
-
-Let's add some basic data to the product:
+Next, we can fill in the following product attributes:
 
 ```html
-<div class="single-product" data-product-id="<?php the_product_id(); ?>">
-
-      <!-- Places first image of the product in this div. -->
-      <div class="image" data-product="image"></div>
+<div data-product-id="<?php the_product_id(); ?>">
 
       <!-- Fills the h3 tags with the product's name. -->
       <h3 data-product="title"></h3>
       
       <!-- Fills the span tags with the product's price. Note that we needed to specify currency type. -->
-      <div class="price">$<span data-product="price"></span></div>
+      <div>$<span data-product="price"></span></div>
+
+      <!-- Fills the div with the description of the product. Includes HTML tags and formatting from Shopify. -->
+      <div data-product="description"></div>
+      
+      <!-- Fills in the product-type. -->
+      <div data-product="type"></div>
+      
+      <!-- Places first image of the product in this div. -->
+      <div data-product="image"></div>
       
       <!-- Show any variations of the product in a dropdown menu. -->
-      <div class="select" data-product="select"></div>
-
-      <!-- Fills the div with the description of the product. -->
-      <div class="description" data-product="description"></div>
+      <div data-product="select"></div>
 
       <!-- Attach event handlers to this button indicating that the selected product (and selected variant, if variations exist) will be added to the Shopify cart. -->
       <button data-product="add-to-cart">Add To Cart</button>
@@ -124,7 +112,7 @@ Let's add some basic data to the product:
 </div>
 ```
 
-When this markup is rendered on the front end, wp-shopify will automatically fill in the necessary information and set up some javascript listeners to handle user interactions.
+See the Examples section for more information.
 
 ### Custom Templates
 
@@ -143,27 +131,38 @@ wp-shopify includes a few standard templates:
 For example, to use the included gallery template (and avoid needing to touch any Underscore code):
 
 ```html
-<div data-template="product-gallery"></div>
+<div data-product-id="<?php the_product_id(); // Don't forget the product wrapper! ?>">
+    <div data-template="product-gallery"></div>
+</div>
 ```
+
+This will automatically create a gallery of `img` elements in the inner `div`, using wp-shopify's built-in template.
 
 #### Custom Templates Reference
 To create your own templates, follow these steps:
 
 1. If one doesn't exist yet, create a folder in your theme's directory called `wshop-templates`.
-1. Create an Underscore template file, treated as an inline script in a PHP file, in that directory. **Set the script's ID to match the file name.** In this script, you have access to the `data` variable, which contains all information about the current product returned from Shopify's API. For example:
-```
+1. Create a PHP file. This file's name will be the template name. For example: `wshop-templates/custom-template.php`.
+1. Create an an inline script in the PHP file to serve as the Underscore template.
+1. **Set the script's ID to match the file name.** For example: 
+
+```html
 <!-- Begin custom template: custom-template.php -->
 <script type="text/template" id="custom-template">
     <% console.log(data); // Show the current information available %>
 </script>
 ```
-That's it! All contents of the `wshop-templates` directory will be included in the footer of your site, hooking into the `get_footer()` function. You can have full control over the data you received from Shopify this way.
+In this script, you have access to the `data` variable, which contains all information about the current product returned from Shopify's API.
+
+That's it! All contents of the `wshop-templates` directory will be included in the footer of your site, hooking into the `get_footer()` function. You can have full control over the data you received from Shopify this way. See the Examples section for more information.
 
 ## What's Going on Behind the Scenes
 
 First, wp-shopify includes the javascript buy SDK off of Shopify's servers. It waits for the document ready event, and then looks for any elements on the page with `data-product-id` set. If it finds any, it fetches all the necessary data from Shopify's servers and saves all of the information. It then searches through child elements of each product and fills in any necessary data based on the data-attributes.
 
 The process of filling in the data for an individual product is wrapped in the function `wshop.renderProduct`. With this information, manually re-rendering the data in any single product is trivial:
+
+The ID you saved to the product in Wordpress was saved with the key `_wshop_product_id`, which was accessed and echoed with `the_product_id()`. The line above will tell wp-shopify that everything within this div will be in reference to this product's ID.
 
 ```js
 jQuery('.single-product').each(wshop.renderProduct);
@@ -233,6 +232,16 @@ There are a few events available for you to hook into:
 * `wshop-product-added` is triggered on `jQuery(document)` when a product is added to the cart.
 
 ## Advanced
+### Wrapper Classes
+There are informational classes added to product wrappers upon rendering:
+* `has-variants` will be added to any product that has variants on Shopify.
+* `product-unavailable` will be added to any product whose inventory is less than or equal to 0 (or is unavailable for any other reason). 
+
+### Wrapper Convenience Functions
+wp-shopify comes with PHP convenience functions to check for, fetch, and display product IDs. Note that `$post` is optional in all of these functions and defaults to the current post.
+* **`has_product( $post )`** returns `true` if the page has a product ID set, `false` if not.
+* **`get_the_product_id( $post )`** is returns the product ID of a given page, as defined in the 'Product ID' metadata. If there is no product ID attached to a page, it returns a blank string.
+* **`the_product_id( $post )`** echoes the return value of `get_the_product_id()`.
 ### Overriding Included Templates
 Making a file with the same name as one of the included templates will override that template - so, for example, if you create a `product-gallery` template in your theme's `wshop-templates` directory, it will override the plugin's default `product-gallery` template.
 ### Setting Up External Custom Styling

--- a/README.md
+++ b/README.md
@@ -33,9 +33,8 @@ First, you'll need your Shopify store up and running.
 ##### Wordpress
 After Shopify has been set up, you'll be able to start the Wordpress installation.
 
-Download this repo and drop it into your plugins folder. Enable it through your plugin settings and then navigate to __Tools > Shopify__. 
-
-Put in your API key (the access token from the Shopify steps), Shopify domain, and app ID. More info here on where to find that: https://help.shopify.com/api/guides/api-credentials
+1. Download this repo and drop it into your plugins folder. Enable it through your plugin settings and then navigate to __Tools > Shopify__. 
+1. Put in your API key (the access token from the Shopify steps), Shopify domain, and app ID. More info here on where to find that: https://help.shopify.com/api/guides/api-credentials
 
 You can now start creating a page or pages that will serve as a placeholder for an individual products. 
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ A Wordpress-Shopify Integration plugin by Funkhaus
 # Table of Contents
 1. [What Is It?](#What-is-it?)
 1. [Setup](#Setup)
-1. [Basic Product Info](#Basic-product-info)
+1. The Product Wrapper
+1. Rendering Information
+    1. `data-` shortcuts
+    1. Templates
 1. [Advanced](#Advanced)
 
 ## What is it?
@@ -21,20 +24,25 @@ wp-shopify is an integration tool built around the [Shopify Buy API](https://hel
 
 From a high-level perspective, the plugin allows you to easily add a basic e-commerce store into a Wordpress site without having to get your hands dirty in all the messy logic that comes with e-commerce projects. It allows you to write templates and develop a theme just as you normally would, pulling product and cart data straight from Shopify and leveraging the API for all the hard work.
 
+The basic workflow is this:
+1. Set up a product wrapper.
+2. Use `data-` attributes to fill in basic product information, and/or
+3. Use templates to fill in more advanced and customized product information.
+
 ## Setup
 
-##### Shopify
+### Shopify
 First, you'll need your Shopify store up and running.
 
 1. Set up a shopify store and enable the [Buy Button Channel](https://www.shopify.com/buy-button).
 1. Create an access token by going to [the Extensions page](https://what-youth-test.myshopify.com/admin/apps/private/extensions) (accessed via Buy Button -> Create Extension, then the Create Extension button in the upper right hand corner).
 1. Note the access token for use later on.
 
-##### Wordpress
+### Wordpress
 After Shopify has been set up, you'll be able to start the Wordpress installation.
 
 1. Download this repo and drop it into your plugins folder. Enable it through your plugin settings and then navigate to __Tools > Shopify__. 
-1. Put in your API key (the access token from the Shopify steps), Shopify domain, and app ID. More info here on where to find that: https://help.shopify.com/api/guides/api-credentials
+1. Put in your API key (the access token from the Shopify steps above), Shopify domain, and app ID. More info here on where to find that: https://help.shopify.com/api/guides/api-credentials
 
 You can now start creating a page or pages that will serve as a placeholder for an individual products. 
 
@@ -42,95 +50,116 @@ You can now start creating a page or pages that will serve as a placeholder for 
 1. You should see a new metabox under the page content that has a field for the product ID. Fill in the product ID from your Shopify store. 
      * The easiest way to find the ID of a product is to navigate to the "edit" page for that product within Shopify, and copy the last section of the URL for that page. For example, if when editing the product your url is *example.myshopify.com/admin/products/__12345__*, then the ID for that product is __12345__.
 
-Once you have at least one product set up, and the Shopify ID saved, then you're ready to start building templates.
+Once you have at least one product set up and the Shopify ID saved, then you're ready to start filling in information.
 
-## Templates
-When you want to display information from Shopify about a product, you can easily do so using a combination of the page metadata and custom data-attributes.
+## The Product Wrapper
 
-1. Prepare a wrapper for your product.
-```php
-<div class="product-wrapper">
-    <!-- Content will live here -->
+First, **prepare a wrapper for your product.** Include a `data-product-id` attribute set to the product ID.
+```html
+<div class="product-wrapper" data-product-id="<?php the_product_id(); ?>">
+    <!-- data-attribute shortcuts and template rendering will live here -->
 </div>
 ```
-2. Add a `data-product-id` attribute to this wrapper element.
-```php
-<div class="product-wrapper" data-product-id=<?php the_product_id(); ?>>
-    <!-- Content will live here -->
-</div>
-```
-`the_product_id()` is a custom wshop function that displays the product ID of a given page, as defined in the 'Product ID' metadata from the previous section.
-3. ***TODO: Continue from here***
+#### Wrapper Classes
+There are informational classes added to product wrappers upon rendering:
+* `has-variants` will be added to any product that has variants on Shopify.
+* `product-unavailable` will be added to any product whose inventory is less than or equal to 0 (or is unavailable for any other reason). 
 
+#### Wrapper Convenience Functions
+wp-shopify comes with PHP convenience functions to check for, fetch, and display product IDs. Note that `$post` is optional in all of these functions and defaults to the current post.
+* **`has_product( $post )`** returns `true` if the page has a product ID set, `false` if not.
+* **`get_the_product_id( $post )`** is returns the product ID of a given page, as defined in the 'Product ID' metadata. If there is no product ID attached to a page, it returns a blank string.
+* **`the_product_id( $post )`** echoes the return value of `get_the_product_id()`.
 
-1. Add a cart (or carts) to your theme wherever you want. Just like information for individual products, carts are templated with regular html and given specific data-attributes to tell this plugin to fill them with Shopify data.
-1. Add a checkout link to your site. When the user clicks this, they will be sent off to the checkout section of Shopify with all of their cart data. Shopify will handle the rest. For example:
-```html
-<?php // Make sure this is an <a> element and contained within a div with data-product-id set ?>
-<a href="#" data-cart="checkout">Checkout</a>
-```
-1. Add any custom templates you'd like to include in your project. For example:
-```html
-<!-- A default template, included with wp-shopify -->
-<div class="gallery" data-template="product-gallery"></div>
+## Rendering Information
+Inside your product wrapper, you can use:
+* `data-product` shortcuts to display information pulled from Shopify, and/or
+* Custom templates for more in-depth display control.
 
-<!-- A user-defined template, located in your-theme-directory/wshop-templates -->
-<div class="custom-area" data-template="custom-template"></div>
-```
-See the Templates section below for more details.
+### `data-product` Shortcuts
 
-
-
-## Product Markup
-
-When writing the markup for an individual product, be it in a grid or on a detail page, you need to first identify the product using the data-attribute `data-product-id`. 
-
-You can use the wrapper functions `get_the_product_id($post)` (which returns the product ID, if any, attached to a post) and `the_product_id($post)` (which echoes the product ID attached to a post) to get a product ID. Note that `$post` is optional in both these wrappers and defaults to the current post.
-
-You can then fill whatever markup you need to within that element, and when you need to pull data about the product from Shopify, just specify the type of data using the data-attribute `data-product`.
-
-### Product data-attribute Reference
+You can set the attribute `data-product` on any HTML tag to fill in some common information about products pulled from Shopify.
 
 - __`data-product="title"`__: The Shopify title of the product.
 - __`data-product="price"`__: The price of the product, does not include symbol of currency.
 - __`data-product="description"`__: The Shopify description of the product.
 - __`data-product="type"`__: The Shopify product-type of the product.
 - __`data-product="image"`__: The featured image of the product from Shopify. Image will be inserted into the element as an img tag.
-- __`data-product="gallery"`__: A gallery of images attached to your product in Shopify. Rendered using `wshop-templates/product-gallery.php`.
 - __`data-product="select"`__: If the product has any variants, this element will be filled with a `<select>` that when changed by the user will switch out which variant of the product is being selected.
 - __`data-product="add-to-cart"`__: When clicked, the element with this data-attribute will add the product (or currently selected variant of the product) to the current user's cart.
 
-Using the above list of attributes, you can fill in whatever product information you need. Here is an example:
+#### Example Shortcut Implementation
 
-Starting with the containing element of the product, we need to tell wp-shopify which product we are working with. Assuming you are in the loop, this is how you start: 
+First, we create the product wrapper:
 
 ```html
 <div class="single-product" data-product-id="<?php the_product_id(); ?>"></div>
 ```
 
-The ID you saved to the product in Wordpress was saved with the key `_wshop_product_id`, which was accessed and echoed with `the_product_id()`, so the line above will tell wp-shopify that everything within this div will be in reference to this product's ID.
+The ID you saved to the product in Wordpress was saved with the key `_wshop_product_id`, which was accessed and echoed with `the_product_id()`. The line above will tell wp-shopify that everything within this div will be in reference to this product's ID.
 
 Let's add some basic data to the product:
 
 ```html
 <div class="single-product" data-product-id="<?php the_product_id(); ?>">
 
+      <!-- Places first image of the product in this div. -->
       <div class="image" data-product="image"></div>
 
+      <!-- Fills the h3 tags with the product's name. -->
       <h3 data-product="title"></h3>
+      
+      <!-- Fills the span tags with the product's price. Note that we needed to specify currency type. -->
       <div class="price">$<span data-product="price"></span></div>
+      
+      <!-- Show any variations of the product in a dropdown menu. -->
       <div class="select" data-product="select"></div>
 
+      <!-- Fills the div with the description of the product. -->
       <div class="description" data-product="description"></div>
 
+      <!-- Attach event handlers to this button indicating that the selected product (and selected variant, if variations exist) will be added to the Shopify cart. -->
       <button data-product="add-to-cart">Add To Cart</button>
 
 </div>
 ```
 
-That's all that we need for the information to be filled in. When this markup is rendered on the front end, wp-shopify will automatically fill in the necessary information and set up some javascript listeners to handle user interactions.
+When this markup is rendered on the front end, wp-shopify will automatically fill in the necessary information and set up some javascript listeners to handle user interactions.
 
-### What's Going on Behind the Scenes
+### Custom Templates
+
+If you want more control over rendering data, you can use custom [underscore.js](http://underscorejs.org/#template) templates. Simply include a `data-template` attribute on your target element and set the value to your template's name.
+
+```html
+<div data-template="my-template-name"></div>
+```
+
+#### Included Templates Reference
+wp-shopify includes a few standard templates:
+
+* `cart-line-item` renders single items in the cart.
+* `product-gallery` renders a product gallery using all images attached to a product.
+
+For example, to use the included gallery template (and avoid needing to touch any Underscore code):
+
+```html
+<div data-template="product-gallery"></div>
+```
+
+#### Custom Templates Reference
+To create your own templates, follow these steps:
+
+1. If one doesn't exist yet, create a folder in your theme's directory called `wshop-templates`.
+1. Create an Underscore template file, treated as an inline script in a PHP file, in that directory. **Set the script's ID to match the file name.** In this script, you have access to the `data` variable, which contains all information about the current product returned from Shopify's API. For example:
+```
+<!-- Begin custom template: custom-template.php -->
+<script type="text/template" id="custom-template">
+    <% console.log(data); // Show the current information available %>
+</script>
+```
+That's it! All contents of the `wshop-templates` directory will be included in the footer of your site, hooking into the `get_footer()` function. You can have full control over the data you received from Shopify this way.
+
+## What's Going on Behind the Scenes
 
 First, wp-shopify includes the javascript buy SDK off of Shopify's servers. It waits for the document ready event, and then looks for any elements on the page with `data-product-id` set. If it finds any, it fetches all the necessary data from Shopify's servers and saves all of the information. It then searches through child elements of each product and fills in any necessary data based on the data-attributes.
 
@@ -145,6 +174,13 @@ Once all the data has been added, wp-shopify will set listeners on `<select>` el
 ## Cart Markup
 
 Any carts on the page will work much in the same way as the products do. The main difference is that the information within a cart is primarily determined by the user, rather than an individual product. For that reason we don't necessarily have to specify a cart ID.
+
+1. Add a cart (or carts) to your theme wherever you want. Just like information for individual products, carts are templated with regular html and given specific data-attributes to tell this plugin to fill them with Shopify data.
+1. Add a checkout link to your site. When the user clicks this, they will be sent off to the checkout section of Shopify with all of their cart data. Shopify will handle the rest. For example:
+```html
+<?php // Make sure this is an <a> element and contained within a div with data-product-id set ?>
+<a href="#" data-cart="checkout">Checkout</a>
+```
 
 ### Cart data-attribute Reference
 
@@ -196,21 +232,9 @@ There are a few events available for you to hook into:
 * `wshop-variant-change` is triggered on its containing product block when a product variant is selected.
 * `wshop-product-added` is triggered on `jQuery(document)` when a product is added to the cart.
 
-### Classes
-
-There are informational classes added to product wrappers upon rendering:
-
-* `has-variants` will be added to any product that has variants on Shopify.
-* `product-unavailable` will be added to any product whose inventory is less than or equal to 0 (or is unavailable for any other reason). 
-
-### Templates
-
-wshop includes a few standard templates, prepared using underscore.js, to help you render data efficiently:
-
-* `wshop-templates/cart-line-item.php` renders single items in the cart.
-* `wshop-templates/product-gallery.php` renders a product gallery using all images attached to a product.
-* 
 ## Advanced
+### Overriding Included Templates
+Making a file with the same name as one of the included templates will override that template - so, for example, if you create a `product-gallery` template in your theme's `wshop-templates` directory, it will override the plugin's default `product-gallery` template.
 ### Setting Up External Custom Styling
 If you want custom styling on the Shopify side of the site, you'll need to set up a couple files on your Shopify account. _Remember that you'll still have to edit any email notifications by hand in your Shopify account settings._
 

--- a/README.md
+++ b/README.md
@@ -10,55 +10,77 @@ A Wordpress-Shopify Integration plugin by Funkhaus
 
 ```
 
-# What is it?
+# Table of Contents
+1. [What Is It?](#What-is-it?)
+1. [Setup](#Setup)
+1. [Basic Product Info](#Basic-product-info)
+1. [Advanced](#Advanced)
+
+## What is it?
 wp-shopify is an integration tool built around the [Shopify Buy API](https://help.shopify.com/api/sdks/js-buy-sdk).
 
 From a high-level perspective, the plugin allows you to easily add a basic e-commerce store into a Wordpress site without having to get your hands dirty in all the messy logic that comes with e-commerce projects. It allows you to write templates and develop a theme just as you normally would, pulling product and cart data straight from Shopify and leveraging the API for all the hard work.
 
-# How do I use it?
-The basic workflow looks like this:
+## Setup
 
-1. Set up a shopify store, you only need to enable the [Buy Button Channel](https://www.shopify.com/buy-button)
-1. Set up a section of your Wordpress site to put products in using pages. A common structure might be something like this:
-      * __Store__
-        * Product 1
-        * Product 2
-        * Product 3
-1. Link each product page in Wordpress to a Shopify product using the page metadata.
-1. Route and template your theme just like you normally would. When you want to display information from Shopify about a product, you can easily do so using a combination of the page metadata and custom data-attributes. For example:
-```html
-<?php // First, associate the div with a product, using the_product_id() ?>
-<div data-product-id="<?php the_product_id(); ?>">
-    <?php // Next, use a custom data attribute to autopopulate the product's title ?>
-    <div data-product="title"></div>
+##### Shopify
+First, you'll need your Shopify store up and running.
+
+1. Set up a shopify store and enable the [Buy Button Channel](https://www.shopify.com/buy-button).
+1. Create an access token by going to [the Extensions page](https://what-youth-test.myshopify.com/admin/apps/private/extensions) (accessed via Buy Button -> Create Extension, then the Create Extension button in the upper right hand corner).
+1. Note the access token for use later on.
+
+##### Wordpress
+After Shopify has been set up, you'll be able to start the Wordpress installation.
+
+Download this repo and drop it into your plugins folder. Enable it through your plugin settings and then navigate to __Tools > Shopify__. 
+
+Put in your API key (the access token from the Shopify steps), Shopify domain, and app ID. More info here on where to find that: https://help.shopify.com/api/guides/api-credentials
+
+You can now start creating a page or pages that will serve as a placeholder for an individual products. 
+
+1. Create and name a page for a product as you normally would. 
+1. You should see a new metabox under the page content that has a field for the product ID. Fill in the product ID from your Shopify store. 
+     * The easiest way to find the ID of a product is to navigate to the "edit" page for that product within Shopify, and copy the last section of the URL for that page. For example, if when editing the product your url is *example.myshopify.com/admin/products/__12345__*, then the ID for that product is __12345__.
+
+Once you have at least one product set up, and the Shopify ID saved, then you're ready to start building templates.
+
+## Templates
+When you want to display information from Shopify about a product, you can easily do so using a combination of the page metadata and custom data-attributes.
+
+1. Prepare a wrapper for your product.
+```php
+<div class="product-wrapper">
+    <!-- Content will live here -->
 </div>
 ```
+2. Add a `data-product-id` attribute to this wrapper element.
+```php
+<div class="product-wrapper" data-product-id=<?php the_product_id(); ?>>
+    <!-- Content will live here -->
+</div>
+```
+`the_product_id()` is a custom wshop function that displays the product ID of a given page, as defined in the 'Product ID' metadata from the previous section.
+3. ***TODO: Continue from here***
+
+
 1. Add a cart (or carts) to your theme wherever you want. Just like information for individual products, carts are templated with regular html and given specific data-attributes to tell this plugin to fill them with Shopify data.
 1. Add a checkout link to your site. When the user clicks this, they will be sent off to the checkout section of Shopify with all of their cart data. Shopify will handle the rest. For example:
 ```html
 <?php // Make sure this is an <a> element and contained within a div with data-product-id set ?>
 <a href="#" data-cart="checkout">Checkout</a>
 ```
+1. Add any custom templates you'd like to include in your project. For example:
+```html
+<!-- A default template, included with wp-shopify -->
+<div class="gallery" data-template="product-gallery"></div>
 
-## Setting Up
-To set up the plugin, download this repo and drop it into your plugins folder. Enable it through the settings and then navigate to __Tools > Shopify__. 
+<!-- A user-defined template, located in your-theme-directory/wshop-templates -->
+<div class="custom-area" data-template="custom-template"></div>
+```
+See the Templates section below for more details.
 
-Put in your API key, Shopify domain, and app ID. More info here on where to find that: https://help.shopify.com/api/guides/api-credentials
 
-The next step after that id to create a page(s) that will serve as a placeholder for an individual product(s). Create and name the page as you normally would, you should see a new metabox under the page content that has a field for the product ID. The easiest way to find the ID of a product is to navigate to the "edit" page for that product within Shopify, and copy the last section of the URL for that page. 
-
-i.e. If when editing the product your url is: *example.myshopify.com/admin/products/__12345__*, then the ID for that product is __12345__.
-
-Once you have at least one product set up, and the Shopify ID saved, then you're ready to start building templates.
-
-### Setting Up External Custom Styling
-If you want custom styling on the Shopify side of the site, you'll need to set up a couple files on your Shopify account. _Remember that you'll still have to edit any email notifications by hand in your Shopify account settings._
-
-__If you just want to be able to edit the CSS in the Shopify editor__, you can upload `/shopify/wp-shopify-theme` at your store's `admin/themes` page. You can edit `wp-shopify.css` in the Assets folder from there and see your changes immediately.
-
-__If you want to set up custom external styling (say, from a CSS file hosted on your own server)__, go to your Shopify themes page (`https://YOUR-STORE-NAME.myshopify.com/admin/themes`), click the ellipsis to the left of 'Customize Theme', and click 'Edit HTML/CSS.' Add in this line: `<link rel="stylesheet" href="YOUR_STYLESHEET_URL_HERE">` to load in an external stylesheet.
-
-**Note that you'll need to deliver your stylesheet over `https` rather than `http` because of Shopify's security settings** - usually this is just a matter of adding the `s` to `http` in the URL.
 
 ## Product Markup
 
@@ -188,6 +210,16 @@ wshop includes a few standard templates, prepared using underscore.js, to help y
 
 * `wshop-templates/cart-line-item.php` renders single items in the cart.
 * `wshop-templates/product-gallery.php` renders a product gallery using all images attached to a product.
+* 
+## Advanced
+### Setting Up External Custom Styling
+If you want custom styling on the Shopify side of the site, you'll need to set up a couple files on your Shopify account. _Remember that you'll still have to edit any email notifications by hand in your Shopify account settings._
+
+__If you just want to be able to edit the CSS in the Shopify editor__, you can upload `/shopify/wp-shopify-theme` at your store's `admin/themes` page. You can edit `wp-shopify.css` in the Assets folder from there and see your changes immediately.
+
+__If you want to set up custom external styling (say, from a CSS file hosted on your own server)__, go to your Shopify themes page (`https://YOUR-STORE-NAME.myshopify.com/admin/themes`), click the ellipsis to the left of 'Customize Theme', and click 'Edit HTML/CSS.' Add in this line: `<link rel="stylesheet" href="YOUR_STYLESHEET_URL_HERE">` to load in an external stylesheet.
+
+**Note that you'll need to deliver your stylesheet over `https` rather than `http` because of Shopify's security settings** - usually this is just a matter of adding the `s` to `http` in the URL.
 
 --------
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Checkout [Links to Shopify checkout]
 
 ## How to Use
 First, link a Shopify product and a Wordpress page:
+
 1. Create a product in Shopify.
 1. Create and name a page for the product in Wordpress.
 1. You should see a new metabox in Wordpress that has a field for the product ID. Fill in the product ID from your Shopify store. 
@@ -95,6 +96,7 @@ Next, prepare the markup for the product pages:
 1. Fill the wrapper with `data-product` shortcuts and/or custom Underscore templates. See below for examples.
 
 Finally, prepare the markup for the cart page:
+
 1. **Wrap your cart in an element with `data-cart-id` set.** `data-cart-id` can be left blank:
 
         <div data-cart-id=""></div>
@@ -198,6 +200,7 @@ There are a few events available for you to hook into:
 * `wshop.cartInitialized` is triggered on `jQuery(document)` when the cart is set up.
 * `wshop.productsInitialized` is triggered on `jQuery(document)` when the products have been initialized, and passes `products.length` as a parameter.
 * `wshop.imageLoaded` is triggered on its containg product block when a `data-product="image"` finishes loading its image.
+* `wshop.productsRendered` is triggered on `jQuery(document)` when all products have finished rendering.
 * `wshop.variantChange` is triggered on its containing product block when a product variant is selected.
 * `wshop.productAdded` is triggered on `jQuery(document)` when a product is added to the cart.
 * `wshop.unavailableProductAdded` is trigged on `jQuery(document)` when the user attempts to add an unavailable product to their cart.
@@ -213,6 +216,9 @@ jQuery(document).on('wshop.productAdded'), function(){
 There are informational classes added to product wrappers upon rendering:
 * `has-variants` will be added to any product that has variants on Shopify.
 * `product-unavailable` will be added to any product whose inventory is less than or equal to 0 (or is unavailable for any other reason). 
+
+There are also classes added to cart wrappers upon rendering:
+* `empty-cart` will be added to an empty cart.
 
 ### Convenience Functions
 wp-shopify comes with PHP convenience functions to check for, fetch, and display product IDs. Note that `$post` is optional in all of these functions and defaults to the current post.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ There are a few events available for you to hook into:
 * `wshop.variantChange` is triggered on its containing product block when a product variant is selected.
 * `wshop.productAdded` is triggered on `jQuery(document)` when a product is added to the cart.
 * `wshop.unavailableProductAdded` is trigged on `jQuery(document)` when the user attempts to add an unavailable product to their cart.
+* `wshop.cartEmpty` is triggered on `jQuery(document)` when rendering a cart with 0 items in it.
 
 For example: 
 ```js

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ You can then fill whatever markup you need to within that element, and when you 
 - __`data-product="description"`__: The Shopify description of the product.
 - __`data-product="type"`__: The Shopify product-type of the product.
 - __`data-product="image"`__: The featured image of the product from Shopify. Image will be inserted into the element as an img tag.
+- __`data-product="gallery"`__: A gallery of images attached to your product in Shopify. Rendered using `wshop-templates/product-gallery.php`.
 - __`data-product="select"`__: If the product has any variants, this element will be filled with a `<select>` that when changed by the user will switch out which variant of the product is being selected.
 - __`data-product="add-to-cart"`__: When clicked, the element with this data-attribute will add the product (or currently selected variant of the product) to the current user's cart.
 
@@ -180,6 +181,13 @@ There are informational classes added to product wrappers upon rendering:
 
 * `has-variants` will be added to any product that has variants on Shopify.
 * `product-unavailable` will be added to any product whose inventory is less than or equal to 0 (or is unavailable for any other reason). 
+
+### Templates
+
+wshop includes a few standard templates, prepared using underscore.js, to help you render data efficiently:
+
+* `wshop-templates/cart-line-item.php` renders single items in the cart.
+* `wshop-templates/product-gallery.php` renders a product gallery using all images attached to a product.
 
 --------
 

--- a/README.md
+++ b/README.md
@@ -10,195 +10,10 @@ A Wordpress-Shopify Integration plugin by Funkhaus
 
 ```
 
-# TODO
-* Convert `data-product="select"` to radio
-
-# Table of Contents
-1. What Is It?
-1. Installation
-1. How to Use
-    1. Setting Up a Product
-    1. Product Templating Reference
-        1. `data-product` Shortcuts
-        1. Custom Templates
-    1. Setting Up a Cart
-1. Examples
-1. Advanced
-    1. Wrapper Classes
-    1. Convenience PHP Functions
-    1. Events
-
 ## What is it?
 wp-shopify is an integration tool built around the [Shopify Buy API](https://help.shopify.com/api/sdks/js-buy-sdk).
 
-wp-shopify integrates a basic e-commerce store into a Wordpress site without having to get your hands dirty in all the messy logic that comes with e-commerce projects. You can write templates and develop a theme just as you normally would, pulling product and cart data straight from Shopify and leveraging the API for all the hard work.
-
-## Installation
-
-### Shopify
-First, you'll need your Shopify store up and running.
-
-1. Set up a Shopify store and enable the [Buy Button Channel](https://www.shopify.com/buy-button).
-1. Create an access token by going to the Buy Button Extensions page at your-site.myshopify.com/admin/apps/private/extensions and clicking **Create Extension** in the top right corner.
-1. Add any product(s) you'll be selling.
-
-### Wordpress
-After Shopify has been set up, you'll be able to start the Wordpress installation.
-
-1. Download this repo and drop it into your plugins folder. Enable it through your plugin settings and then navigate to __Tools > Shopify__. 
-1. Put in your API key (the access token from step 2 above), Shopify domain, and app ID. More info here on where to find that: https://help.shopify.com/api/guides/api-credentials
-
-You can now start creating a page or pages that will serve as a placeholder for an individual product. 
-
-## How to Use
-After installation, you'll need to set up both your product on Shopify and a page for that product in Wordpress.
-
-### Setting Up a Product Page
-1. Create and name a page for a product as you normally would in Wordpress.
-1. You should see a new metabox under the page content that has a field for the product ID. Fill in the product ID from your Shopify store. 
-     * The easiest way to find the ID of a product is to navigate to the "edit" page for that product within Shopify, and copy the last section of the URL for that page. For example, if when editing the product your url is *example.myshopify.com/admin/products/__12345__*, then the ID for that product is __12345__.
-
-Once you have at least one product set up and the Shopify ID saved, then you're ready to start templating product information.
-
-### Product Templating Reference
-First, **prepare a wrapper for your product.** Include a `data-product-id` attribute set to the product ID.
-```html
-<div class="product-wrapper" data-product-id="<?php the_product_id(); ?>">
-    <!-- the_product_id() will fill in the product ID - see "Advanced" below -->
-</div>
-```
-
-Inside your wrapper, you can use any combination of these features to display product information:
-* `data-product` shortcuts to display basic information, and/or
-* Custom templates for more in-depth display control.
-
-#### `data-product` Shortcuts
-You can set the attribute `data-product` on any HTML tag to fill in some common information about products pulled from Shopify.
-
-First, we create the product wrapper:
-
-```html
-<div data-product-id="<?php the_product_id(); ?>">
-    
-</div>
-```
-
-Next, we can fill in the following product attributes:
-
-```html
-<div data-product-id="<?php the_product_id(); ?>">
-
-      <!-- Fills the h3 tags with the product's name. -->
-      <h3 data-product="title"></h3>
-      
-      <!-- Fills the span tags with the product's price. Note that we needed to specify currency type. -->
-      <div>$<span data-product="price"></span></div>
-
-      <!-- Fills the div with the description of the product. Includes HTML tags and formatting from Shopify. -->
-      <div data-product="description"></div>
-      
-      <!-- Fills in the product-type. -->
-      <div data-product="type"></div>
-      
-      <!-- Places first image of the product in this div. -->
-      <div data-product="image"></div>
-      
-      <!-- Show any variations of the product in a dropdown menu. -->
-      <div data-product="select"></div>
-
-      <!-- Attach event handlers to this button indicating that the selected product (and selected variant, if variations exist) will be added to the Shopify cart. -->
-      <button data-product="add-to-cart">Add To Cart</button>
-
-</div>
-```
-
-See the Examples section for more information.
-
-### Custom Templates
-
-If you want more control over rendering data, you can use custom [underscore.js](http://underscorejs.org/#template) templates. Simply include a `data-template` attribute on your target element and set the value to your template's name.
-
-```html
-<div data-template="my-template-name"></div>
-```
-
-#### Included Templates Reference
-wp-shopify includes a few standard templates:
-
-* `cart-line-item` renders single items in the cart.
-* `product-gallery` renders a product gallery using all images attached to a product.
-
-For example, to use the included gallery template (and avoid needing to touch any Underscore code):
-
-```html
-<div data-product-id="<?php the_product_id(); // Don't forget the product wrapper! ?>">
-    <div data-template="product-gallery"></div>
-</div>
-```
-
-This will automatically create a gallery of `img` elements in the inner `div`, using wp-shopify's built-in template.
-
-#### Custom Templates Reference
-To create your own templates, follow these steps:
-
-1. If one doesn't exist yet, create a folder in your theme's directory called `wshop-templates`.
-1. Create a PHP file. This file's name will be the template name. For example: `wshop-templates/custom-template.php`.
-1. Create an an inline script in the PHP file to serve as the Underscore template.
-1. **Set the script's ID to match the file name.** For example: 
-
-```html
-<!-- Begin custom template: custom-template.php -->
-<script type="text/template" id="custom-template">
-    <% console.log(data); // Show the current information available %>
-</script>
-```
-In this script, you have access to the `data` variable, which contains all information about the current product returned from Shopify's API.
-
-That's it! All contents of the `wshop-templates` directory will be included in the footer of your site, hooking into the `get_footer()` function. You can have full control over the data you received from Shopify this way. See the Examples section for more information.
-
-## Setting Up a Cart
-Any carts on the page will work much in the same way as the products do. The main difference is that the information within a cart is primarily determined by the user, rather than an individual product. For that reason we don't necessarily have to specify a cart ID.
-
-### Cart `data`-attribute Reference
-Remember to wrap the cart with a data-cart-id, even if the data-cart-id is empty!
-
-```html
-<div data-cart-id="">
-
-    <!-- The individual items -->
-    <div data-cart="line-items">
-        <!-- Each item in the cart will be rendered using wshop-templates/cart-line-item.php here -->
-    </div>
-    
-    <!-- The subtotal of the user's cart -->
-    <div data-cart="subtotal"></div>
-    
-    <!-- The total number of items in the current cart (default 0) -->
-    <div data-cart="line-item-count"></div>
- 
-    <!-- MUST BE AN <a> TAG. href will automatically be set to Shopify checkout URL. You can also use wshop.cart.checkoutUrl at any time to get the checkout URL. -->
-    <a data-cart="checkout">Checkout</a>
-    
-    <!-- Increment one of the quantity of the given item in the cart -->
-    <div data-cart="add"></div>
-    
-    <!-- Decrement one of the quantity of the given item in the cart -->
-    <div data-cart="subtract"></div>
-    
-    <!-- Remove an item from the cart entirely -->
-    <div data-cart="remove"></div>
-
-</div>
-```
-
-### Cart Custom Templates Reference
-Custom Underscore cart templates are set up in the same way as custom product templates. You have access to a `data` variable that contains all the information about each item in a cart, as well as the quantity in the cart and other stats. For example:
-
-```html
-<script type="text/template" id="cart-line-item">
-    <% console.log(data); // Log available data %>
-</script>
-```
+wp-shopify integrates a basic Shopify store into a Wordpress site quickly and cleanly. You can write templates and develop a theme just as you normally would, pulling product and cart data straight from Shopify and leveraging the API for all the hard work.
 
 ## Examples
 Assuming we have a product on Shopify with the following information:
@@ -256,6 +71,125 @@ Checkout [Links to Shopify checkout]
 
 ```
 
+## Installation
+
+1. *Shopify:* Set up a Shopify store and enable the [Buy Button Channel](https://www.shopify.com/buy-button).
+1. Create an access token by going to the Buy Button Extensions page at your-site.myshopify.com/admin/apps/private/extensions and clicking **Create Extension** in the top right corner.
+1. *Wordpress:* Download this repo and drop it into your plugins folder. Enable it through your plugin settings and then navigate to __Tools > Shopify__. 
+1. Put your API key (the access token from step 2 above), Shopify domain, and app ID in the wp-shopify settings. More info here on where to find that Shopify info can be found [here]( https://help.shopify.com/api/guides/api-credentials).
+
+## How to Use
+First, link a Shopify product and a Wordpress page:
+1. Create a product in Shopify.
+1. Create and name a page for the product in Wordpress.
+1. You should see a new metabox in Wordpress that has a field for the product ID. Fill in the product ID from your Shopify store. 
+     * The easiest way to find the ID of a product is to navigate to the "edit" page for that product within Shopify, and copy the last section of the URL for that page. For example, if when editing the product your url is *example.myshopify.com/admin/products/__12345__*, then the ID for that product is __12345__.
+
+Next, prepare the markup for the product pages:
+
+1. **Wrap your product in an element with `data-product-id` set correctly.** For example, when in the Loop:
+    
+        <div class="product-wrapper" data-product-id="<?php the_product_id(); ?>">
+            <!-- the_product_id() will fill in the product ID - see "Advanced" below -->
+        </div>
+1. Fill the wrapper with `data-product` shortcuts and/or custom Underscore templates. See below for examples.
+
+Finally, prepare the markup for the cart page:
+1. **Wrap your cart in an element with `data-cart-id` set.** `data-cart-id` can be left blank:
+
+        <div data-cart-id=""></div>
+        
+1. Fill the wrapper with `data-cart` shortcuts and/or custom Underscore templates. See below for examples.
+
+## Product Templates
+
+#### Using `data-product`
+Place any of the following attributes on elements in the `data-product-id` wrap. They will automatically fill themselves with the relevant information.
+
+* `data-product="title"` - The product's name.
+* `data-product="price"` - The price. Currency is not specified automatically.
+* `data-product="description"` - The description. Includes HTML tags and formatting.
+* `data-product="type"` - The product type.
+* `data-product="image'` - The first image uploaded to this product on Shopify.
+* `data-product="select"` - Variations (size, color, etc.) in a drop-down menu.
+* `data-product="radio"` - Variations (size, color, etc.) in a radio menu.
+* `data-product="add-to-cart"` - Automatically attach a click event handler to this element. When activated, the selected product (and variation, if any), will be added to the user's cart.
+
+### Using Custom Product Templates
+You can use custom [underscore.js](http://underscorejs.org/#template) templates:
+
+```html
+<div data-template="my-template-name"></div>
+```
+
+Set the `data-template` attribute equal to one of these included templates:
+
+* `product-gallery` (renders a product gallery using all images attached to a product)
+* `variants-radio` (renders a product's variants as radio buttons - does not handle callbacks! Use `data-product="radio"` to render the template and have wp-shopify set up the callbacks for you)
+* `variants-select` (renders a product's variants as a dropdown menu - does not handle callbacks! Use `data-product="select"` to render the template and have wp-shopify set up the callbacks for you)
+
+You can also build your own custom template:
+
+1. If one doesn't exist yet, create a folder in your theme's directory called `wshop-templates`.
+1. Create a PHP file. This file's name will be the template name. For example: `wshop-templates/custom-template.php`.
+1. Create an an inline script in the PHP file to serve as the Underscore template.
+1. Set the script's ID to match the file name.
+
+Custom templates have access to the `data` variable, which contains all information about the current product returned from Shopify's API.
+
+All contents of the `wshop-templates` directory will be included in the footer of your site, hooking into the `get_footer()` function. You can have full control over the data you received from Shopify this way.
+
+## Setting Up a Cart
+Any carts on the page will work much in the same way as the products do. The main difference is that we don't necessarily have to specify a cart ID:
+```html
+<!-- Perfectly valid cart wrapper -->
+<div data-cart-id="">
+
+</div>
+```
+# TODO: Start here
+You can use `data-cart` attributes just like `data-product`, as well as custom Underscore templates:
+
+```html
+<div data-cart-id="">
+
+    <!-- The individual items -->
+    <div data-cart="line-items">
+        <!-- Each item in the cart will be rendered using wshop-templates/cart-line-item.php here -->
+    </div>
+    
+    <!-- The subtotal of the user's cart -->
+    <div data-cart="subtotal"></div>
+    
+    <!-- The total number of items in the current cart (default 0) -->
+    <div data-cart="line-item-count"></div>
+ 
+    <!-- MUST BE AN <a> TAG. href will automatically be set to Shopify checkout URL. You can also use wshop.cart.checkoutUrl at any time to get the checkout URL. -->
+    <a data-cart="checkout">Checkout</a>
+    
+    <!-- Increment one of the quantity of the given item in the cart -->
+    <div data-cart="add"></div>
+    
+    <!-- Decrement one of the quantity of the given item in the cart -->
+    <div data-cart="subtract"></div>
+    
+    <!-- Remove an item from the cart entirely -->
+    <div data-cart="remove"></div>
+
+</div>
+```
+
+### Cart Custom Templates Reference
+Custom Underscore cart templates are set up in the same way as custom product templates. You have access to a `data` variable that contains all the information about each item in a cart, as well as the quantity in the cart and other stats. For example:
+
+```html
+<script type="text/template" id="cart-line-item">
+    <% console.log(data); // Log available data %>
+</script>
+```
+
+
+
 ## Advanced
 ### Events
 
@@ -266,6 +200,7 @@ There are a few events available for you to hook into:
 * `wshop.imageLoaded` is triggered on its containg product block when a `data-product="image"` finishes loading its image.
 * `wshop.variantChange` is triggered on its containing product block when a product variant is selected.
 * `wshop.productAdded` is triggered on `jQuery(document)` when a product is added to the cart.
+* `wshop.unavailableProductAdded` is trigged on `jQuery(document)` when the user attempts to add an unavailable product to their cart.
 
 For example: 
 ```js
@@ -309,6 +244,29 @@ jQuery('.single-product').each(wshop.renderProduct);
 ```
 
 Once all the data has been added, wp-shopify will set listeners on `<select>` elements, `add-to-cart` elements, and anything else that will need to interact with the state of the product.
+
+## Starting Points
+Product wrapper:
+```html
+<div data-product-id="<?php the_product_id(); ?>">
+
+</div>
+```
+Cart wrapper:
+```html
+<div data-cart-id="">
+
+</div>
+```
+Custom Underscore template:
+```html
+<!-- Begin custom template: custom-template.php -->
+<script type="text/template" id="custom-template">
+    <% console.log(data); // Show the current information available %>
+</script>
+```
+
+
 
 --------
 

--- a/README.md
+++ b/README.md
@@ -183,8 +183,9 @@ There are a few events available for you to hook into:
 * `wshop.productsRendered` is triggered on `jQuery(document)` when all products have finished rendering.
 * `wshop.variantChange` is triggered on its containing product block when a product variant is selected.
 * `wshop.productAdded` is triggered on `jQuery(document)` when a product is added to the cart.
-* `wshop.unavailableProductAdded` is trigged on `jQuery(document)` when the user attempts to add an unavailable product to their cart.
+* `wshop.unavailableProductAdded` is trigged on the containing product block when the user attempts to add an unavailable product to their cart.
 * `wshop.cartEmpty` is triggered on `jQuery(document)` when rendering a cart with 0 items in it.
+* `wshop.allProductsRendered` is triggered on `jQuery(document)` when all product blocks have finised rendering.
 
 For example: 
 ```js

--- a/js/wshop.js
+++ b/js/wshop.js
@@ -48,8 +48,10 @@ var wshop = {
         });
 
         // Bind increment buttons
+        // TODO
 
         // Bind decrement buttons
+        // TODO
 
         // Bind 'remove' buttons
         jQuery(document).on('click', '*[data-cart="remove"]', function(e){
@@ -107,8 +109,7 @@ var wshop = {
                     wshop.renderProduct.bind($block.get(0))();
 
                     // make sure we've rendered all products before triggering callback
-                    total--;
-                    if( total == 0 ){
+                    if( --total == 0 ){
                         jQuery(document).trigger('wshop.productsRendered');
                     }
                 });
@@ -121,7 +122,7 @@ var wshop = {
     },
 
 /*
- * function to render everything within the page's cart
+ * function to render everything within the page's carts
  */
     renderCarts: function(){
 
@@ -153,8 +154,6 @@ var wshop = {
         $carts.each(function(){
 
             $cart = jQuery(this);
-
-
 
             $cart.find('*[data-cart]').each(function(){
 
@@ -195,7 +194,7 @@ var wshop = {
 
     handleIncrement: function(e){
 
-        // get ID from data-att
+        // get ID from data-attr
         var lineitemId = jQuery(this).data('lineitemId');
 
         // no ID? abort
@@ -212,7 +211,7 @@ var wshop = {
 
     handleDecrement: function(e){
 
-        // get ID from data-att
+        // get ID from data-attr
         var lineitemId = jQuery(this).data('lineitemId');
 
         // no ID? abort
@@ -229,7 +228,7 @@ var wshop = {
 
     handleRemove: function(e){
 
-        // get ID
+        // get ID from data-attr
         var lineitemId = jQuery(this).data('lineitemId');
 
         // no ID? abort
@@ -242,13 +241,16 @@ var wshop = {
     },
 
     applyTemplate: function(templateName, data){
-        // find relevant script ID
+        // find template script by ID
         var $templateScript = jQuery('#' + templateName);
 
         // return if no template present
         if( ! $templateScript.length ){
+
             console.log('No template with the ID #' + templateName + ' found');
-            return true;
+
+            // This will be rendered in renderTemplate, so treat it as an HTML comment
+            return '<!-- No template with the ID #' + templateName + ' found! -->';
         }
 
         // prep template data name
@@ -257,6 +259,7 @@ var wshop = {
         // pre-compile template
         var template = _.template( $templateScript.html() );
 
+        // Apply template formatting and return result
         return jQuery( template(data) );
     },
 
@@ -324,6 +327,7 @@ var wshop = {
 
                     }.bind(this);
 
+                    // Set src and load image
                     var targetImage = product.images[currentImage].src;
                     img.src = targetImage;
 
@@ -364,7 +368,7 @@ var wshop = {
                 // Render radio
                 wshop.renderTemplate.bind(this)('variants-radio', product);
 
-                // add change listener to newly-rendered select
+                // add change listener to newly-rendered radio
                 jQuery(this).find('input[type=radio]').on('change', function(e){
 
                     // get name from radio value
@@ -406,7 +410,7 @@ var wshop = {
             jQuery(document).trigger('wshop.templateRendered', [ jQuery(this) ]);
         });
 
-
+        // Trigger "all rendered" event
         $productBlock.trigger('wshop.allBlocksRendered');
 
     },
@@ -420,8 +424,10 @@ var wshop = {
 
         } else {
 
+            // Find product parent
             var product = jQuery(this).closest('*[data-product-id]').data('product');
 
+            // Add to cart
             wshop.cart.addVariants({ variant: product.selectedVariant, quantity: 1 })
                 .then(function(){
 

--- a/js/wshop.js
+++ b/js/wshop.js
@@ -372,7 +372,7 @@ var wshop = {
         });
 
 
-        //$productBlock.trigger('wshop.');
+        $productBlock.trigger('wshop.allBlocksRendered');
 
     },
 

--- a/js/wshop.js
+++ b/js/wshop.js
@@ -413,17 +413,26 @@ var wshop = {
 
     handleAddToCart: function(){
 
-        var product = jQuery(this).closest('*[data-product-id]').data('product');
+        if( jQuery(this).parents('.product-unavailable').length ){
 
-        wshop.cart.addVariants({ variant: product.selectedVariant, quantity: 1 })
-            .then(function(){
+            // We have a .product-unavailable parent, so trigger the relevant event
+            jQuery(document).trigger('wshop.unavailableProductAdded');
 
-                // re-render any carts
-                wshop.renderCarts();
+        } else {
 
-                jQuery(document).trigger('wshop.productAdded');
+            var product = jQuery(this).closest('*[data-product-id]').data('product');
 
-            });
+            wshop.cart.addVariants({ variant: product.selectedVariant, quantity: 1 })
+                .then(function(){
+
+                    // re-render any carts
+                    wshop.renderCarts();
+
+                    jQuery(document).trigger('wshop.productAdded');
+
+                });
+
+        }
 
     }
 

--- a/js/wshop.js
+++ b/js/wshop.js
@@ -269,27 +269,6 @@ var wshop = {
             // set product type
             if ( jQuery(this).attr('data-product') == 'type' ) jQuery(this).text( product.attrs.product_type );
 
-            // render gallery
-            if( jQuery(this).attr('data-product') == 'gallery' ){
-
-                // set main variable name in underscore
-                _.templateSettings.variable = 'product';
-
-                // pre-compile gallery template
-                var galleryTemplate;
-                if ( jQuery( 'script.wshop-product-gallery' ).length ){
-                    galleryTemplate = _.template(
-                        jQuery( 'script.wshop-product-gallery' ).html()
-                    );
-                }
-
-                // render gallery template
-                $renderedGallery = jQuery(galleryTemplate(product));
-
-                // append gallery to this element
-                jQuery(this).html($renderedGallery);
-            }
-
             // set images
             if ( jQuery(this).attr('data-product') == 'image' ){
 
@@ -389,6 +368,7 @@ var wshop = {
             jQuery(this).html($rendered);
 
             // callbacks
+            jQuery(document).trigger('wshop.templateRendered', [ jQuery(this) ]);
         });
 
 

--- a/js/wshop.js
+++ b/js/wshop.js
@@ -241,6 +241,35 @@ var wshop = {
 
     },
 
+    applyTemplate: function(templateName, data){
+        // find relevant script ID
+        var $templateScript = jQuery('#' + templateName);
+
+        // return if no template present
+        if( ! $templateScript.length ){
+            console.log('No template with the ID #' + templateName + ' found');
+            return true;
+        }
+
+        // prep template data name
+        _.templateSettings.variable = 'data';
+
+        // pre-compile template
+        var template = _.template( $templateScript.html() );
+
+        return jQuery( template(data) );
+    },
+
+    renderTemplate: function(templateName, data){
+
+        // Create rendered template
+        var $applied = wshop.applyTemplate(templateName, data);
+
+        // Place inside bound element
+        jQuery(this).html( $applied );
+
+    },
+
 /*
  * function to render all of the data within a product element
  */
@@ -307,17 +336,10 @@ var wshop = {
             // set select
             if ( jQuery(this).attr('data-product') == 'select' && product.variants.length > 1 ){
 
-                // build html for select
-                var selectElem = product.options.map(function(option) {
-                    return '<select name="' + option.name + '"><option selected disabled>' + option.name + '</option>' + option.values.map(function(value) {
-                        return '<option value="' + value + '">' + value + '</option>';
-                    }) + '</select>';
-                })[0];
+                // Render select
+                wshop.renderTemplate.bind(this)('variants-select', product);
 
-                // add select to this element
-                jQuery(this).html(selectElem);
-
-                // add change listener to select
+                // add change listener to newly-rendered select
                 jQuery(this).find('select').on('change', function(e){
 
                     // get name a val from select
@@ -334,6 +356,30 @@ var wshop = {
 
                 });
 
+            }
+
+            // set radio
+            if( jQuery(this).attr('data-product') == 'radio' && product.variants.length > 1 ){
+
+                // Render radio
+                wshop.renderTemplate.bind(this)('variants-radio', product);
+
+                // add change listener to newly-rendered select
+                jQuery(this).find('input[type=radio]').on('change', function(e){
+
+                    // get name from radio value
+                    var name = e.target.name;
+                    var value = e.target.value;
+
+                    // set this variant as selected
+                    product.options.filter(function(option) {
+                        return option.name === name;
+                    })[0].selected = value;
+
+                    // trigger event on this product
+                    $productBlock.trigger('wshop.variantChange');
+
+                });
             }
 
             // add listener to add-to-cart button
@@ -353,26 +399,8 @@ var wshop = {
             // find data-template value
             var templateName = jQuery(this).attr('data-template');
 
-            // find relevant script ID
-            var $templateScript = jQuery('#' + templateName);
-
-            // return if no template present
-            if( ! $templateScript.length ){
-                console.log('No template with the ID #' + templateName + ' found');
-                return true;
-            }
-
-            // prep template name
-            _.templateSettings.variable = 'data';
-
-            // pre-compile template
-            var template = _.template( $templateScript.html() );
-
             // render template
-            $rendered = jQuery( template(product) );
-
-            // inject rendered object into block
-            jQuery(this).html($rendered);
+            wshop.renderTemplate.bind(this)(templateName, product);
 
             // callbacks
             jQuery(document).trigger('wshop.templateRendered', [ jQuery(this) ]);

--- a/js/wshop.js
+++ b/js/wshop.js
@@ -48,10 +48,18 @@ var wshop = {
         });
 
         // Bind increment buttons
-        // TODO
+        jQuery(document).on('click', '*[data-cart="add"]', function(e){
+            wshop.handleIncrement.bind(
+                jQuery(this).closest('*[data-lineitem-id]')
+            )();
+        });
 
         // Bind decrement buttons
-        // TODO
+        jQuery(document).on('click', '*[data-cart="subtract"]', function(e){
+            wshop.handleDecrement.bind(
+                jQuery(this).closest('*[data-lineitem-id]')
+            )();
+        });
 
         // Bind 'remove' buttons
         jQuery(document).on('click', '*[data-cart="remove"]', function(e){

--- a/js/wshop.js
+++ b/js/wshop.js
@@ -132,9 +132,9 @@ var wshop = {
 
         // pre-compile cart line-item template
         var lineItemTemplate;
-        if ( jQuery( 'script.wshop-cart-line-item' ).length ){
+        if ( jQuery( 'script#cart-line-item' ).length ){
             lineItemTemplate = _.template(
-                jQuery( 'script.wshop-cart-line-item' ).html()
+                jQuery( 'script#cart-line-item' ).html()
             );
         }
 
@@ -163,23 +163,47 @@ var wshop = {
                     // loop through any line items in cart
                     _.each(wshop.cart.lineItems, function(lineItem){
 
+                        // Render line item
                         var $lineItem = jQuery(lineItemTemplate(lineItem));
 
-                        // render this line item using template
+                        // Save line item ID
+                        $lineItem.attr('data-lineitem-id', lineItem.id);
+
+                        // Append rendered line item
                         $dataLine.append( $lineItem );
 
-                        // bind any incremenet/decremenet buttons to corresponding functions
+/*
+                        // bind any increment/decremenet buttons to corresponding functions
                         $lineItem.find('*[data-cart="add"]').on('click', wshop.handleIncrement.bind($lineItem));
                         $lineItem.find('*[data-cart="subtract"]').on('click', wshop.handleDecrement.bind($lineItem));
 
                         // bind 'remove' button to 'decrement' function
-                        $lineItem.find('*[data-cart="remove"]').on('click', wshop.handleDecrement.bind($lineItem));
+                        $lineItem.find('*[data-cart="remove"]').on('click', function(){
+                            wshop.handleDecrement.bind($lineItem);
+                            console.log(this);
+                        });
+*/
 
 
                     });
 
                 }
 
+            });
+
+            // Bind increment buttons
+
+            // Bind decrement buttons
+
+            // bind 'remove' buttons
+            jQuery(document).on('click', '*[data-cart="remove"]', function(e){
+                wshop.handleRemove.bind(
+                    jQuery(this).closest('*[data-lineitem-id]')
+                /*
+_.find( jQuery('*[data-lineitem-id]'), function($lineItem){
+                    return $lineItem.data('lineitem-id') == jQuery(this).closest(')
+                }
+*/)();
             });
 
         });

--- a/js/wshop.js
+++ b/js/wshop.js
@@ -58,7 +58,7 @@ var wshop = {
             )();
         });
 
-        jQuery(document).trigger('wshop-cart-initialized');
+        jQuery(document).trigger('wshop.cartInitialized');
 
     },
 
@@ -109,14 +109,14 @@ var wshop = {
                     // make sure we've rendered all products before triggering callback
                     total--;
                     if( total == 0 ){
-                        jQuery(document).trigger('wshop-products-rendered');
+                        jQuery(document).trigger('wshop.productsRendered');
                     }
                 });
 
         });
 
         // trigger event
-        jQuery(document).trigger('wshop.products-initialized', [ $products.length ]);
+        jQuery(document).trigger('wshop.productsInitialized', [ $products.length ]);
 
     },
 
@@ -182,19 +182,6 @@ var wshop = {
 
                         // Append rendered line item
                         $dataLine.append( $lineItem );
-
-/*
-                        // bind any increment/decremenet buttons to corresponding functions
-                        $lineItem.find('*[data-cart="add"]').on('click', wshop.handleIncrement.bind($lineItem));
-                        $lineItem.find('*[data-cart="subtract"]').on('click', wshop.handleDecrement.bind($lineItem));
-
-                        // bind 'remove' button to 'decrement' function
-                        $lineItem.find('*[data-cart="remove"]').on('click', function(){
-                            wshop.handleDecrement.bind($lineItem);
-                            console.log(this);
-                        });
-*/
-
 
                     });
 
@@ -304,7 +291,7 @@ var wshop = {
                         jQuery(this).append($image);
 
                         // trigger image-loaded event
-                        jQuery(this).trigger('wshop-image-loaded');
+                        jQuery(this).trigger('wshop.imageLoaded');
 
                     }.bind(this);
 
@@ -343,7 +330,7 @@ var wshop = {
                     })[0].selected = value;
 
                     // trigger event on this product
-                    $productBlock.trigger('wshop-variant-change');
+                    $productBlock.trigger('wshop.variantChange');
 
                 });
 
@@ -406,7 +393,7 @@ var wshop = {
                 // re-render any carts
                 wshop.renderCarts();
 
-                jQuery(document).trigger('wshop-product-added');
+                jQuery(document).trigger('wshop.productAdded');
 
             });
 

--- a/js/wshop.js
+++ b/js/wshop.js
@@ -241,7 +241,7 @@ var wshop = {
         // do nothing if no product
         if ( ! product ) return;
 
-        // add class if need be
+        // add classes if need be
         if ( product.variants && product.variants.length > 1 ){
             $productBlock.addClass('has-variants');
         }
@@ -261,6 +261,27 @@ var wshop = {
             if ( jQuery(this).attr('data-product') == 'description' ) jQuery(this).html( product.description );
             // set product type
             if ( jQuery(this).attr('data-product') == 'type' ) jQuery(this).text( product.attrs.product_type );
+
+            // render gallery
+            if( jQuery(this).attr('data-product') == 'gallery' ){
+
+                // set main variable name in underscore
+                _.templateSettings.variable = 'product';
+
+                // pre-compile gallery template
+                var galleryTemplate;
+                if ( jQuery( 'script.wshop-product-gallery' ).length ){
+                    galleryTemplate = _.template(
+                        jQuery( 'script.wshop-product-gallery' ).html()
+                    );
+                }
+
+                // render gallery template
+                $renderedGallery = jQuery(galleryTemplate(product));
+
+                // append gallery to this element
+                jQuery(this).html($renderedGallery);
+            }
 
             // set images
             if ( jQuery(this).attr('data-product') == 'image' ){

--- a/js/wshop.js
+++ b/js/wshop.js
@@ -430,6 +430,13 @@ var wshop = {
 
     handleAddToCart: function(){
 
+        // Add to cart
+        addToCart.bind(this)(1);
+
+    },
+
+    addToCart: function(quantity){
+
         if( jQuery(this).parents('.product-unavailable').length ){
 
             // We have a .product-unavailable parent, so trigger the relevant event
@@ -440,8 +447,8 @@ var wshop = {
             // Find product parent
             var product = jQuery(this).closest('*[data-product-id]').data('product');
 
-            // Add to cart
-            wshop.cart.addVariants({ variant: product.selectedVariant, quantity: 1 })
+            // Add selected variant and selected quantity to cart
+            wshop.cart.addVariants({ variant: product.selectedVariant, quantity: quantity || 1 })
                 .then(function(){
 
                     // re-render any carts
@@ -450,9 +457,7 @@ var wshop = {
                     jQuery(document).trigger('wshop.productAdded');
 
                 });
-
         }
-
     }
 
 };

--- a/js/wshop.js
+++ b/js/wshop.js
@@ -178,6 +178,11 @@ var wshop = {
                     // empty any existing line-items
                     $dataLine.empty();
 
+                    // trigger a callback on an empty cart
+                    if( wshop.cart.lineItems.length == 0 ){
+                        jQuery(document).trigger('wshop.cartEmpty');
+                    }
+
                     // loop through any line items in cart
                     _.each(wshop.cart.lineItems, function(lineItem){
 

--- a/js/wshop.js
+++ b/js/wshop.js
@@ -253,7 +253,11 @@ var wshop = {
 
     },
 
-    applyTemplate: function(templateName, data){
+    renderTemplate: function(templateName, data){
+
+        // Save HTML for applied template
+        var $applied = '';
+
         // find template script by ID
         var $templateScript = jQuery('#' + templateName);
 
@@ -262,24 +266,18 @@ var wshop = {
 
             console.log('No template with the ID #' + templateName + ' found');
 
-            // This will be rendered in renderTemplate, so treat it as an HTML comment
-            return '<!-- No template with the ID #' + templateName + ' found! -->';
+            // Set an HTML comment
+            $applied =  '<!-- No template with the ID #' + templateName + ' found! -->';
+        } else {
+            // prep template data name
+            _.templateSettings.variable = 'data';
+
+            // pre-compile template
+            var template = _.template( $templateScript.html() );
+
+            // Apply template formatting and return result
+            $applied = jQuery( template(data) );
         }
-
-        // prep template data name
-        _.templateSettings.variable = 'data';
-
-        // pre-compile template
-        var template = _.template( $templateScript.html() );
-
-        // Apply template formatting and return result
-        return jQuery( template(data) );
-    },
-
-    renderTemplate: function(templateName, data){
-
-        // Create rendered template
-        var $applied = wshop.applyTemplate(templateName, data);
 
         // Place inside bound element
         jQuery(this).html( $applied );
@@ -403,8 +401,8 @@ var wshop = {
             if ( jQuery(this).attr('data-product') == 'add-to-cart' ){
 
                 // may already be set, so unset
-                jQuery(this).off('click', wshop.handleAddToCart);
-                jQuery(this).on('click', wshop.handleAddToCart);
+                jQuery(this).off('click', wshop.addSingleToCart);
+                jQuery(this).on('click', wshop.addSingleToCart);
 
             }
 
@@ -424,13 +422,13 @@ var wshop = {
         });
 
         // Trigger "all rendered" event
-        $productBlock.trigger('wshop.allBlocksRendered');
+        $productBlock.trigger('wshop.allProductsRendered');
 
     },
 
-    handleAddToCart: function(){
+    addSingleToCart: function(){
 
-        // Add to cart
+        // Add one of an item to cart
         addToCart.bind(this)(1);
 
     },
@@ -440,7 +438,7 @@ var wshop = {
         if( jQuery(this).parents('.product-unavailable').length ){
 
             // We have a .product-unavailable parent, so trigger the relevant event
-            jQuery(document).trigger('wshop.unavailableProductAdded');
+            jQuery(this).parents('.product-unavailable').trigger('wshop.unavailableProductAdded');
 
         } else {
 

--- a/js/wshop.js
+++ b/js/wshop.js
@@ -47,6 +47,17 @@ var wshop = {
 
         });
 
+        // Bind increment buttons
+
+        // Bind decrement buttons
+
+        // Bind 'remove' buttons
+        jQuery(document).on('click', '*[data-cart="remove"]', function(e){
+            wshop.handleRemove.bind(
+                jQuery(this).closest('*[data-lineitem-id]')
+            )();
+        });
+
         jQuery(document).trigger('wshop-cart-initialized');
 
     },
@@ -191,21 +202,6 @@ var wshop = {
 
             });
 
-            // Bind increment buttons
-
-            // Bind decrement buttons
-
-            // bind 'remove' buttons
-            jQuery(document).on('click', '*[data-cart="remove"]', function(e){
-                wshop.handleRemove.bind(
-                    jQuery(this).closest('*[data-lineitem-id]')
-                /*
-_.find( jQuery('*[data-lineitem-id]'), function($lineItem){
-                    return $lineItem.data('lineitem-id') == jQuery(this).closest(')
-                }
-*/)();
-            });
-
         });
 
     },
@@ -261,7 +257,7 @@ _.find( jQuery('*[data-lineitem-id]'), function($lineItem){
 /*
  * function to render all of the data within a product element
  */
-    renderProduct: function(){ // switch back to binding
+    renderProduct: function(){
 
         // get elem
         $productBlock = jQuery(this);

--- a/wshop-core.php
+++ b/wshop-core.php
@@ -28,15 +28,48 @@
  */
     function wshop_underscore_templates() {
 
-        // default template
-        $template = 'wshop-templates/cart-line-item.php';
+        // find all stock templates
+        $paths_to_include = glob(WP_PLUGIN_DIR . '/wp-shopify/wshop-templates/*.php');
 
-        // check for theme-defined template
-        if ( locate_template('wshop-templates/cart-line-item.php') ){
-            $template = locate_template('wshop-templates/cart-line-item.php');
+        // find all custom templates (defined in the current theme)
+        $user_template_paths = glob(get_stylesheet_directory() . '/wshop-templates/*.php');
+
+        // loop through user-defined templates and replace any stock templates
+        foreach( $user_template_paths as $custom_template_path ){
+
+            // find the basename of the current custom template
+            $basename = basename($custom_template_path);
+
+            // create an array of just the stock template basenames
+            $standard_basenames = array_map( function ($v){
+                return basename($v);
+            }, $paths_to_include);
+
+            // are we overriding a stock template?
+            if( in_array($basename, $standard_basenames) ){
+
+                // find the stock template's index
+                $index = array_search($basename, $standard_basenames);
+
+                // replace the stock template with the custom one
+                $paths_to_include[$index] = $custom_template_path;
+
+            } else {
+                // we're not overriding a stock template
+                // add the new custom template to the list of templates to include
+                $paths_to_include[] = $custom_template_path;
+            }
         }
 
-        include($template);
+        if( count($paths_to_include) > 0 ){
+
+            // include each template file
+            foreach( $paths_to_include as $path ){
+                include($path);
+            }
+
+        }
+
     }
     add_action( 'wp_footer', 'wshop_underscore_templates', 100 );
 

--- a/wshop-settings.php
+++ b/wshop-settings.php
@@ -21,7 +21,7 @@
     ?>
 
 		<div class="wrap">
-			<h2>Funkstagram Options</h2>
+			<h2>wp-shopify Options</h2>
 			<form action="options.php" method="post" id="wshop_settings">
 				<?php settings_fields('wshop_settings'); ?>
 				<table class="form-table">

--- a/wshop-templates/README.md
+++ b/wshop-templates/README.md
@@ -10,11 +10,37 @@ A Wordpress-Shopify Integration plugin by Funkhaus
 
 ```
 
-# Line Item Markup
+# Templates
+
+This directory contains templates used in rendering various wshop components. Templates are processed with [underscore.js](http://underscorejs.org/#template).
+
+## Customizing Templates
+
+You can customize any template you see here within your own theme, without having to edit the files in this directory, by doing the following:
+
+1. Create a directory in your theme folder called `wshop-templates`.
+1. Create a template with the same name as the one you want to replace. For example, to replace the stock line item template, you'd create `cart-line-item.php`. Put that file in the `wshop-templates` directory from the previous step.
+1. Wrap your templating in a script tag with the class `wshop-[name of the template]`. For example, the contents of the `cart-line-item.php` file from the previous step would look like this:
+
+```
+<script type="text/template" class="wshop-cart-line-item">
+
+    <!-- Your custom template here... -->
+    
+</script>
+```
+
+That's it! Your custom template should be up and running.
+
+## Gallery Markup
+
+
+
+## Line Item Markup
 
 When you automatically create a cart of items using the Wordpress Shopify plugin, each item will be rendered using this PHP/Underscore template.
 
-# How Do I Use It?
+### How Do I Use It?
 
 You have several properties available through the `data` object accessible in the Underscore template. Some of the most useful include:
 

--- a/wshop-templates/cart-line-item.php
+++ b/wshop-templates/cart-line-item.php
@@ -1,5 +1,5 @@
 <!-- BEGIN: Cart line item template (this template is looped in the cart) -->
-<script type="text/template" class="wshop-cart-line-item">
+<script type="text/template" id="cart-line-item">
 
     <div class="line-item" data-lineitem-id="<%- data.id %>">
 

--- a/wshop-templates/product-gallery.php
+++ b/wshop-templates/product-gallery.php
@@ -1,0 +1,18 @@
+<!-- BEGIN: Product gallery template -->
+<script type="text/template" class="wshop-product-gallery">
+
+    <div class="product-gallery">
+
+        <% for( var i = 1; i < product.images.length; i++ ){ // loop through all except the first image %>
+
+            <div class="slide">
+
+                <img src="<%= product.images[i].src %>">
+
+            </div>
+
+        <% } %>
+
+    </div>
+
+</script>

--- a/wshop-templates/product-gallery.php
+++ b/wshop-templates/product-gallery.php
@@ -1,13 +1,13 @@
 <!-- BEGIN: Product gallery template -->
-<script type="text/template" class="wshop-product-gallery">
+<script type="text/template" id="gallery-template">
 
     <div class="product-gallery">
 
         <% for( var i = 1; i < product.images.length; i++ ){ // loop through all except the first image %>
 
-            <div class="slide">
+            <div class="slide" style="background-image: url(<%= product.images[i].src %>);">
 
-                <img src="<%= product.images[i].src %>">
+                <img src="<%= data.images[i].src %>">
 
             </div>
 

--- a/wshop-templates/variants-radio.php
+++ b/wshop-templates/variants-radio.php
@@ -1,0 +1,18 @@
+<!-- Begin custom template: variants-radio.php -->
+<script type="text/template" id="variants-radio">
+
+    <% data.options.forEach(function(option){ %>
+
+        <form class="variants-wrap">
+
+            <% option.values.forEach(function(variant){  %>
+
+                <input type="radio" name="<%= option.name %>" value="<%= variant %>"> <%= variant %>
+
+            <% }); %>
+
+        </form>
+
+    <% }); %>
+
+</script>

--- a/wshop-templates/variants-select.php
+++ b/wshop-templates/variants-select.php
@@ -1,0 +1,25 @@
+<!-- Begin custom template: variants-select.php -->
+<script type="text/template" id="variants-select">
+
+    <% data.options.forEach(function(option){ %>
+
+        <select name="<%= option.name %>" class="variants-select">
+
+            <option selected disabled>
+                <%= option.name %>
+            </option>
+
+            <% option.values.forEach(function(value){ %>
+
+                <option value="<%= value %>">
+                    <%= value %>
+                </option>
+
+            <% }); %>
+
+        </select>
+
+    <% }); %>
+
+
+</script>


### PR DESCRIPTION
@drewbaker and @jrobson153 - I made a couple templating-focused changes in these commits and wanted you to double-check before committing to master. 

Basically, the plugin will now include any PHP files it finds in wshop-templates/, not just ones we specifically name. It'll also look for any in the current theme's wshop-templates/ directory, overriding the default templates with any custom ones it finds in the theme.

I set these up to make adding future templates easier - I had to include one for creating a product gallery, and this seemed like the most future-proof way to do it.

Let me know how it looks and if I should change anything - thanks!
